### PR TITLE
Make repository installable with Vim Package Managers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,3 +14,16 @@ Currently supported:
 **NOTE:** all of these plugins are still under development and some of them are
 still incomplete!
 
+
+## Installation via Package Manager
+
+Your can install the plugin with a package Manager, i.e., [Pathogen](https://github.com/tpope/vim-pathogen), [NeoBundle](https://github.com/Shougo/neobundle.vim), or [Plug](https://github.com/junegunn/vim-plug) should work
+
+For example with [Plug](https://github.com/junegunn/vim-plug) add the following `Plug` line between the `begin` and `end` call:
+```vim
+call plug#begin()
+... 
+Plug 'lifepillar/vim-formal-package', {'do': './convert_to_plugin.sh'}
+...
+call plug#end()
+```

--- a/convert_to_plugin.sh
+++ b/convert_to_plugin.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -u
+
+CURDIR=$(dirname -- $(realpath "$0"))
+cd $CURDIR
+
+# Copy the files into a plugin structure
+cp -r start/*/* .
+
+touch -a .gitignore
+# Add the plugin directories to .gitignore
+grep -qxF 'autoload/' .gitignore || echo 'autoload/' >> .gitignore
+grep -qxF 'compiler/' .gitignore || echo 'compiler/' >> .gitignore
+grep -qxF 'ftdetect/' .gitignore || echo 'ftdetect/' >> .gitignore
+grep -qxF 'ftplugin/' .gitignore || echo 'ftplugin/' >> .gitignore
+grep -qxF 'indent/' .gitignore || echo 'indent/' >> .gitignore
+grep -qxF 'syntax/' .gitignore || echo 'syntax/' >> .gitignore

--- a/remove_plugin.sh
+++ b/remove_plugin.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -u
+
+CURDIR=$(dirname -- $(realpath "$0"))
+cd $CURDIR
+
+# Remove the plugin directories from .gitignore
+sed -i '/autoload/d' .gitignore
+sed -i '/compiler/d' .gitignore
+sed -i '/ftdetect/d' .gitignore
+sed -i '/ftplugin/d' .gitignore
+sed -i '/indent/d' .gitignore
+sed -i '/syntax/d' .gitignore
+
+# Delete the plugin structure
+rm -rf autoload compiler ftdetect ftplugin indent syntax


### PR DESCRIPTION
I moved the plugin files into a structure that is recognized by many package manager for `vim`.
The change is tested with [plug](https://github.com/junegunn/vim-plug). The plugin installs and at least syntax highlighting is active afterwards.

Please consider merging to make this plugin easier to install.